### PR TITLE
fix #7 - Resolve bridge singleton workspace mismatch across OpenCode sessions

### DIFF
--- a/packages/opencode-plugin-cursor/src/tools/cli.ts
+++ b/packages/opencode-plugin-cursor/src/tools/cli.ts
@@ -109,6 +109,7 @@ export function createCliTools(args: {
           cmdArgs.push("--mode", mode);
         }
 
+        cmdArgs.push("--workspace", args.cwd);
         cmdArgs.push("--output-format", outputFormat);
 
         if (toolArgs.model) {


### PR DESCRIPTION
## Summary

Fixes #7 — the bridge singleton freezes the workspace at first launch, causing subsequent OpenCode sessions in different projects to target the wrong directory.

<img width="612" height="674" alt="image" src="https://github.com/user-attachments/assets/87318535-f9e9-419a-ba5c-4c6c84eaedec" />

## Changes

- **Bridge `server.ts`**: Accept per-request workspace override via `X-Cursor-Workspace` header, falling back to `config.workspace` when absent
- **Plugin `bridge.ts`**: `ensureBridgeProcess()` now queries `/health` to compare the running bridge's workspace against the current project — restarts the bridge on mismatch
- **Plugin `cli.ts`**: `cursor_cli_run` now passes `--workspace` explicitly (previously only set `cwd` on the child process)

## How it works

Two layers of defense:

1. **Bridge restart on mismatch** (plugin side): When a new OpenCode session starts, the plugin checks `/health` for the current bridge workspace. If it doesn't match the new project directory, the old bridge is stopped and a new one is spawned with the correct `CURSOR_BRIDGE_WORKSPACE`.

2. **Per-request override** (bridge side): Even if multiple sessions share one bridge, each request can pass `X-Cursor-Workspace` to override the workspace for that specific Cursor CLI invocation. This enables future multi-project support without requiring bridge restarts.