### PR TITLE
feat: v0.2.0 - stream-json support, MCP tools, bridge limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ npm --workspaces run build
 Create `~/.config/opencode/plugins/cursor-opencode-auth.ts`:
 
 ```ts
-// Uses your local checkout (v0.1.1+) instead of a cached npm install.
+// Uses your local checkout (v0.2.0+) instead of a cached npm install.
 export { CursorPlugin } from "/path/to/cursor-opencode-auth/packages/opencode-plugin-cursor/dist/index.js";
 ```
 
@@ -100,7 +100,7 @@ If you prefer installing from npm instead of a local checkout, pin the version i
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["opencode-plugin-cursor@0.1.1"]
+  "plugin": ["opencode-plugin-cursor@0.2.0"]
 }
 ```
 
@@ -143,8 +143,10 @@ The OpenCode plugin adds tools:
 
 - `cursor_cli_status` (shows Cursor CLI auth status)
 - `cursor_cli_models` (lists Cursor CLI models)
-- `cursor_cli_run` (runs Cursor CLI in `--print` mode)
+- `cursor_cli_run` (runs Cursor CLI in `--print` mode; supports `stream-json` output for full tool call visibility)
 - `cursor_cli_patch` (runs Cursor CLI in an isolated git worktree and returns a patch)
+- `cursor_cli_mcp_list` (lists MCP servers configured in Cursor CLI)
+- `cursor_cli_mcp_tools` (lists tools from a specific Cursor MCP server)
 - `cursor_cloud_*` tools (launch and manage Cursor Cloud Agents via `https://api.cursor.com/v0/...`)
 
 ## Repo layout
@@ -162,6 +164,22 @@ The OpenCode plugin adds tools:
 - `cursor_cli_run`: one-off Cursor CLI response (defaults to Cursor `ask` mode)
 - `cursor_cli_patch`: run Cursor in an isolated git worktree and return a diff inside `<patch>...</patch>` (apply with OpenCode `patch`)
 - `cursor_cloud_*`: manage Cursor Cloud Agents via `https://api.cursor.com/v0/...` (requires `CURSOR_API_KEY`)
+
+## Known limitations
+
+### Bridge-as-provider creates nested agent loops
+
+Cursor CLI is a full coding agent (it reads files, calls tools, writes code), not a model. When you use `cursor/<model>` as an OpenCode provider, OpenCode sends a prompt to the bridge, which runs Cursor's own agent loop, then returns only the final text. This means:
+
+- Two agent loops run with no coordination (OpenCode's loop wrapping Cursor's loop).
+- Cursor's internal tool calls (file reads, edits, shell commands) are invisible to OpenCode.
+- OpenCode treats Cursor's agent output as a "model response," which is a semantic mismatch.
+
+**Recommended:** Use the CLI tools (`cursor_cli_run` with `outputFormat: "stream-json"`, or `cursor_cli_patch`) instead of the provider for full visibility into what Cursor did. The provider approach works for simple question-answering but loses important context for coding tasks.
+
+### OpenCode does not support plugin-registered providers
+
+OpenCode's plugin API supports registering tools and event hooks, but not custom model providers. Providers must be configured via `opencode.json` with an AI SDK package (e.g., `@ai-sdk/openai-compatible`). This is why the bridge server exists as a workaround. A proper integration would require OpenCode to add `provider()` registration to its plugin API (see [OpenCode plugin docs](https://opencode.ai/docs/plugins/)).
 
 ## Safety notes
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -268,6 +268,23 @@ Plan: start with (1), add (2) behind a flag, and document tradeoffs.
 - Implement MCP stdio server
 - Mirror tools for both Cursor + OpenCode
 
+## Upstream dependencies
+
+### OpenCode: plugin-registered providers
+
+OpenCode's plugin API (`@opencode-ai/plugin`) supports `tool()` registration and event hooks, but **not provider registration**. Providers are configured via `opencode.json` with an AI SDK package (e.g., `@ai-sdk/openai-compatible`). This forces the bridge server workaround for the provider use case.
+
+A proper integration would require OpenCode to add a `provider()` registration function to the plugin API, allowing plugins to register model providers directly. Until then, the bridge creates an agent-wrapping-agent architecture where Cursor CLI's full agent loop is opaque to OpenCode.
+
+### Cursor CLI: stream-json as the primary integration format
+
+Cursor CLI's `--output-format stream-json` produces rich NDJSON events (tool calls, assistant messages, session metadata). This project now uses `stream-json` in both the plugin tools and the bridge to:
+
+- Surface Cursor's tool call activity in `cursor_cli_run` and `cursor_cli_patch`
+- Extract clean assistant text in the bridge (filtering out tool call noise)
+
+If Cursor changes the NDJSON event schema, the parsers in `lib/streamJson.ts` (both packages) will need updating.
+
 ## Success criteria
 
 - From OpenCode, a user can:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -27,7 +27,7 @@ Example (local checkout):
 
 ```ts
 // ~/.config/opencode/plugins/cursor.ts
-// Uses your local checkout (v0.1.1+) instead of a cached npm install.
+// Uses your local checkout (v0.2.0+) instead of a cached npm install.
 export { CursorPlugin } from "/abs/path/to/cursor-opencode-auth/packages/opencode-plugin-cursor/dist/index.js";
 ```
 
@@ -100,7 +100,7 @@ After publishing `opencode-plugin-cursor` to npm:
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["opencode-plugin-cursor@0.1.1"]
+  "plugin": ["opencode-plugin-cursor@0.2.0"]
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
       }
     },
     "packages/cursor-openai-bridge": {
-      "version": "0.1.1",
+      "version": "0.2.0",
       "bin": {
         "cursor-openai-bridge": "dist/cli.js"
       },
@@ -84,7 +84,7 @@
       }
     },
     "packages/opencode-plugin-cursor": {
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@opencode-ai/plugin": "^1.0.0"

--- a/packages/cursor-openai-bridge/package.json
+++ b/packages/cursor-openai-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cursor-openai-bridge",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cursor-openai-bridge/src/cli.ts
+++ b/packages/cursor-openai-bridge/src/cli.ts
@@ -3,7 +3,7 @@ import { startBridgeServer } from "./lib/server.js";
 
 async function main() {
   const config = loadBridgeConfig();
-  startBridgeServer({ version: "0.1.1", config });
+  startBridgeServer({ version: "0.2.0", config });
 }
 
 main().catch((err) => {

--- a/packages/cursor-openai-bridge/src/lib/server.ts
+++ b/packages/cursor-openai-bridge/src/lib/server.ts
@@ -12,6 +12,7 @@ import {
   type OpenAiChatCompletionRequest,
 } from "./openai.js";
 import { run } from "./process.js";
+import { extractAssistantText } from "./streamJson.js";
 
 type ModelCache = { at: number; models: CursorCliModel[] };
 
@@ -106,7 +107,7 @@ export function startBridgeServer(opts: BridgeServerOptions): http.Server {
 
         cmdArgs.push("--workspace", requestWorkspace);
         cmdArgs.push("--model", model);
-        cmdArgs.push("--output-format", "text");
+        cmdArgs.push("--output-format", "stream-json");
         cmdArgs.push(prompt);
 
         const out = await run(config.agentBin, cmdArgs, {
@@ -123,7 +124,14 @@ export function startBridgeServer(opts: BridgeServerOptions): http.Server {
           return;
         }
 
-        const content = out.stdout.trim();
+        // Extract only the assistant's text from the NDJSON stream,
+        // discarding tool-call events so the OpenAI response is clean.
+        const assistantText = extractAssistantText(out.stdout);
+        if (!assistantText) {
+          // eslint-disable-next-line no-console
+          console.warn("No assistant text found in stream-json output; falling back to raw stdout.");
+        }
+        const content = assistantText || out.stdout.trim();
         const id = `chatcmpl_${randomUUID().replace(/-/g, "")}`;
         const created = Math.floor(Date.now() / 1000);
 
@@ -212,6 +220,20 @@ export function startBridgeServer(opts: BridgeServerOptions): http.Server {
     console.log(`- approve mcps: ${config.approveMcps}`);
     // eslint-disable-next-line no-console
     console.log(`- required api key: ${config.requiredKey ? "yes" : "no"}`);
+    // eslint-disable-next-line no-console
+    console.log("");
+    // eslint-disable-next-line no-console
+    console.log(
+      "NOTE: Cursor CLI is a full coding agent, not a model. Using it as an",
+    );
+    // eslint-disable-next-line no-console
+    console.log(
+      "OpenAI provider creates nested agent loops. For full visibility into",
+    );
+    // eslint-disable-next-line no-console
+    console.log(
+      "Cursor's actions, use cursor_cli_run (with stream-json) or cursor_cli_patch instead.",
+    );
   });
 
   return server;

--- a/packages/cursor-openai-bridge/src/lib/streamJson.ts
+++ b/packages/cursor-openai-bridge/src/lib/streamJson.ts
@@ -1,0 +1,35 @@
+/**
+ * Minimal parser for Cursor CLI `--output-format stream-json` NDJSON output.
+ *
+ * The bridge only needs the final assistant text to return as an
+ * OpenAI-compatible completion response.
+ */
+
+/** Extract all assistant message text from stream-json NDJSON output. */
+export function extractAssistantText(stdout: string): string {
+  const parts: string[] = [];
+
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    let event: any;
+    try {
+      event = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+
+    if (event?.type === "assistant") {
+      const content = event.message?.content;
+      if (Array.isArray(content)) {
+        const text = content
+          .map((p: any) => (p?.type === "text" && p?.text ? p.text : ""))
+          .join("");
+        if (text) parts.push(text);
+      }
+    }
+  }
+
+  return parts.join("\n\n");
+}

--- a/packages/opencode-plugin-cursor/package.json
+++ b/packages/opencode-plugin-cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-plugin-cursor",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "OpenCode plugin that bridges to Cursor CLI and Cloud Agents API",
   "license": "MIT",
   "type": "module",

--- a/packages/opencode-plugin-cursor/src/lib/streamJson.ts
+++ b/packages/opencode-plugin-cursor/src/lib/streamJson.ts
@@ -1,0 +1,289 @@
+/**
+ * Parser for Cursor CLI's `--output-format stream-json` NDJSON output.
+ *
+ * Each line is a JSON object with a `type` field. Known event types:
+ *   - system  (subtype: "init")   – session metadata
+ *   - user                        – echoed user prompt
+ *   - assistant                   – model response text
+ *   - tool_call (subtype: "started" | "completed") – tool invocations
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SystemInitEvent {
+  type: "system";
+  subtype: "init";
+  model?: string;
+  session_id?: string;
+  cwd?: string;
+  permissionMode?: string;
+  apiKeySource?: string;
+}
+
+export interface UserEvent {
+  type: "user";
+  message: { role: "user"; content: Array<{ type: string; text?: string }> };
+  session_id?: string;
+}
+
+export interface AssistantEvent {
+  type: "assistant";
+  message: {
+    role: "assistant";
+    content: Array<{ type: string; text?: string }>;
+  };
+  session_id?: string;
+}
+
+export interface ToolCallEvent {
+  type: "tool_call";
+  subtype: "started" | "completed";
+  call_id: string;
+  tool_call: Record<string, any>;
+  session_id?: string;
+}
+
+export type CursorStreamEvent =
+  | SystemInitEvent
+  | UserEvent
+  | AssistantEvent
+  | ToolCallEvent
+  | { type: string; [key: string]: any }; // forward-compat for unknown events
+
+// ---------------------------------------------------------------------------
+// Parsed summary
+// ---------------------------------------------------------------------------
+
+export interface ToolCallSummary {
+  callId: string;
+  toolName: string;
+  args: Record<string, any>;
+  result?: Record<string, any>;
+  completed: boolean;
+}
+
+export interface StreamJsonSummary {
+  model?: string;
+  sessionId?: string;
+  cwd?: string;
+  assistantMessages: string[];
+  toolCalls: ToolCallSummary[];
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+/** Parse the full stdout of a `--output-format stream-json` CLI run. */
+export function parseStreamJsonOutput(stdout: string): StreamJsonSummary {
+  const summary: StreamJsonSummary = {
+    assistantMessages: [],
+    toolCalls: [],
+  };
+
+  const toolMap = new Map<string, ToolCallSummary>();
+
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    let event: CursorStreamEvent;
+    try {
+      event = JSON.parse(trimmed);
+    } catch {
+      continue; // skip non-JSON lines (e.g. Cursor CLI banners)
+    }
+
+    if (!event || typeof event.type !== "string") continue;
+
+    switch (event.type) {
+      case "system": {
+        const e = event as SystemInitEvent;
+        if (e.subtype === "init") {
+          summary.model = e.model;
+          summary.sessionId = e.session_id;
+          summary.cwd = e.cwd;
+        }
+        break;
+      }
+
+      case "assistant": {
+        const e = event as AssistantEvent;
+        const text = extractContentText(e.message?.content);
+        if (text) summary.assistantMessages.push(text);
+        break;
+      }
+
+      case "tool_call": {
+        const e = event as ToolCallEvent;
+        const { toolName, args, result } = describeToolCall(e.tool_call);
+
+        if (e.subtype === "started") {
+          const entry: ToolCallSummary = {
+            callId: e.call_id,
+            toolName,
+            args,
+            completed: false,
+          };
+          toolMap.set(e.call_id, entry);
+          summary.toolCalls.push(entry);
+        } else if (e.subtype === "completed") {
+          const existing = toolMap.get(e.call_id);
+          if (existing) {
+            existing.completed = true;
+            existing.result = result;
+          } else {
+            summary.toolCalls.push({
+              callId: e.call_id,
+              toolName,
+              args,
+              result,
+              completed: true,
+            });
+          }
+        }
+        break;
+      }
+
+      // Unknown event types are silently ignored for forward-compat.
+      default:
+        break;
+    }
+  }
+
+  return summary;
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+/** Produce a human-readable summary of a stream-json run. */
+export function formatStreamJsonSummary(summary: StreamJsonSummary): string {
+  const sections: string[] = [];
+
+  // Header
+  const headerParts: string[] = [];
+  if (summary.model) headerParts.push(`Model: ${summary.model}`);
+  if (summary.sessionId) headerParts.push(`Session: ${summary.sessionId}`);
+  if (headerParts.length) sections.push(headerParts.join("\n"));
+
+  // Tool calls
+  if (summary.toolCalls.length > 0) {
+    const lines = [`## Tool Calls (${summary.toolCalls.length})`];
+    for (let i = 0; i < summary.toolCalls.length; i++) {
+      const tc = summary.toolCalls[i];
+      const argStr = formatArgs(tc.args);
+      const resultStr = tc.completed ? formatToolResult(tc.result) : "(running)";
+      lines.push(`${i + 1}. ${tc.toolName}(${argStr}) -> ${resultStr}`);
+    }
+    sections.push(lines.join("\n"));
+  }
+
+  // Assistant response
+  if (summary.assistantMessages.length > 0) {
+    sections.push(
+      "## Assistant Response\n" + summary.assistantMessages.join("\n\n"),
+    );
+  }
+
+  return sections.join("\n\n");
+}
+
+/** Extract only the final assistant text (for use in the bridge). */
+export function extractAssistantText(summary: StreamJsonSummary): string {
+  return summary.assistantMessages.join("\n\n");
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function extractContentText(
+  content: Array<{ type: string; text?: string }> | undefined,
+): string {
+  if (!content || !Array.isArray(content)) return "";
+  return content
+    .map((part) => (part.type === "text" && part.text ? part.text : ""))
+    .join("");
+}
+
+/**
+ * Cursor's tool_call object uses keys like `readToolCall`, `editToolCall`,
+ * `shellToolCall`, etc. Extract the tool name and args/result from whichever
+ * key is present.
+ */
+function describeToolCall(tc: Record<string, any>): {
+  toolName: string;
+  args: Record<string, any>;
+  result?: Record<string, any>;
+} {
+  if (!tc || typeof tc !== "object") {
+    return { toolName: "unknown", args: {} };
+  }
+
+  for (const key of Object.keys(tc)) {
+    if (!key.endsWith("ToolCall") && !key.endsWith("toolCall")) continue;
+    const inner = tc[key];
+    if (!inner || typeof inner !== "object") continue;
+
+    // Derive a readable name: "readToolCall" -> "read", "editToolCall" -> "edit"
+    const toolName = key.replace(/[Tt]oolCall$/, "") || key;
+    const { args, result, ...rest } = inner;
+    return {
+      toolName,
+      args: args ?? rest,
+      result: result ?? undefined,
+    };
+  }
+
+  // Fallback: use the first key as the tool name
+  const firstKey = Object.keys(tc)[0];
+  if (firstKey) {
+    const inner = tc[firstKey];
+    return {
+      toolName: firstKey,
+      args: typeof inner === "object" ? (inner?.args ?? inner) : {},
+      result: typeof inner === "object" ? inner?.result : undefined,
+    };
+  }
+
+  return { toolName: "unknown", args: {} };
+}
+
+function formatArgs(args: Record<string, any>): string {
+  const entries = Object.entries(args);
+  if (entries.length === 0) return "";
+  // Show at most 3 args, truncate long values
+  return entries
+    .slice(0, 3)
+    .map(([k, v]) => {
+      const val = typeof v === "string" ? truncate(v, 60) : JSON.stringify(v);
+      return `${k}: ${val}`;
+    })
+    .join(", ");
+}
+
+function formatToolResult(result: Record<string, any> | undefined): string {
+  if (!result) return "done";
+
+  // Check for common result shapes from Cursor CLI
+  if ("success" in result) {
+    const s = result.success;
+    if (s?.totalLines != null) return `${s.totalLines} lines read`;
+    if (s?.content != null) return `success (${truncate(String(s.content), 40)})`;
+    return "success";
+  }
+  if ("error" in result) {
+    return `error: ${truncate(String(result.error), 60)}`;
+  }
+
+  return "done";
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return JSON.stringify(s);
+  return JSON.stringify(s.slice(0, max - 3) + "...");
+}

--- a/packages/opencode-plugin-cursor/src/tools/cli.ts
+++ b/packages/opencode-plugin-cursor/src/tools/cli.ts
@@ -6,6 +6,10 @@ import { tool } from "@opencode-ai/plugin";
 
 import { parseModelList } from "../lib/models.js";
 import { run } from "../lib/process.js";
+import {
+  formatStreamJsonSummary,
+  parseStreamJsonOutput,
+} from "../lib/streamJson.js";
 
 export function createCliTools(args: {
   agentBin: string;
@@ -81,9 +85,11 @@ export function createCliTools(args: {
           .optional()
           .describe("Cursor model ID (optional, e.g. gpt-5.2)"),
         outputFormat: tool.schema
-          .enum(["text", "json"])
+          .enum(["text", "json", "stream-json"])
           .optional()
-          .describe("Cursor CLI output format (default: text)"),
+          .describe(
+            "Cursor CLI output format (default: text). Use stream-json to see tool calls and intermediate steps.",
+          ),
         force: tool.schema
           .boolean()
           .optional()
@@ -130,6 +136,11 @@ export function createCliTools(args: {
           throw new Error(
             `Cursor CLI failed (exit ${res.code}).\n` + `stderr: ${res.stderr.trim()}`,
           );
+        }
+
+        if (outputFormat === "stream-json") {
+          const summary = parseStreamJsonOutput(res.stdout);
+          return formatStreamJsonSummary(summary);
         }
 
         return res.stdout.trim();
@@ -214,7 +225,7 @@ export function createCliTools(args: {
             );
           }
 
-          const cmdArgs: string[] = ["--print", "--force", "--output-format", "text"];
+          const cmdArgs: string[] = ["--print", "--force", "--output-format", "stream-json"];
           // Cursor CLI only accepts --mode=ask|plan. "agent" is the default when --mode is omitted.
           if (mode !== "agent") cmdArgs.push("--mode", mode);
           if (toolArgs.model) cmdArgs.push("--model", toolArgs.model);
@@ -260,15 +271,19 @@ export function createCliTools(args: {
           });
 
           const patchText = diff.stdout.trimEnd();
-          const summary = nameStatus.code === 0 ? nameStatus.stdout.trim() : "";
+          const fileSummary = nameStatus.code === 0 ? nameStatus.stdout.trim() : "";
+
+          // Parse stream-json output for structured activity report.
+          const parsed = parseStreamJsonOutput(cursorRes.stdout);
+          const activityText = formatStreamJsonSummary(parsed);
 
           if (!patchText) {
             return [
               "<cursor_cli_patch>",
               "<message>Cursor completed, but produced no git diff (no changes).</message>",
-              summary ? `<summary>\n${summary}\n</summary>` : "",
-              cursorRes.stdout.trim()
-                ? `<cursor_stdout>\n${cursorRes.stdout.trim()}\n</cursor_stdout>`
+              fileSummary ? `<summary>\n${fileSummary}\n</summary>` : "",
+              activityText
+                ? `<cursor_activity>\n${activityText}\n</cursor_activity>`
                 : "",
               cursorRes.stderr.trim()
                 ? `<cursor_stderr>\n${cursorRes.stderr.trim()}\n</cursor_stderr>`
@@ -281,9 +296,9 @@ export function createCliTools(args: {
 
           return [
             "<cursor_cli_patch>",
-            summary ? `<summary>\n${summary}\n</summary>` : "",
-            cursorRes.stdout.trim()
-              ? `<cursor_stdout>\n${cursorRes.stdout.trim()}\n</cursor_stdout>`
+            fileSummary ? `<summary>\n${fileSummary}\n</summary>` : "",
+            activityText
+              ? `<cursor_activity>\n${activityText}\n</cursor_activity>`
               : "",
             cursorRes.stderr.trim()
               ? `<cursor_stderr>\n${cursorRes.stderr.trim()}\n</cursor_stderr>`
@@ -311,6 +326,63 @@ export function createCliTools(args: {
             await rm(tempDir, { recursive: true, force: true });
           }
         }
+      },
+    }),
+
+    cursor_cli_mcp_list: tool({
+      description:
+        "List MCP servers configured in Cursor CLI (agent mcp list).",
+      args: {
+        timeoutMs: tool.schema
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("Timeout in ms (optional)"),
+      },
+      async execute(toolArgs) {
+        const res = await run(args.agentBin, ["mcp", "list"], {
+          cwd: args.cwd,
+          timeoutMs: toolArgs.timeoutMs ?? 60_000,
+        });
+        if (res.code !== 0) {
+          throw new Error(
+            `agent mcp list failed (exit ${res.code}).\n${res.stderr.trim()}`,
+          );
+        }
+        return res.stdout.trim();
+      },
+    }),
+
+    cursor_cli_mcp_tools: tool({
+      description:
+        "List tools provided by a specific MCP server in Cursor CLI (agent mcp list-tools <server>).",
+      args: {
+        serverName: tool.schema
+          .string()
+          .describe("Name of the MCP server to inspect"),
+        timeoutMs: tool.schema
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("Timeout in ms (optional)"),
+      },
+      async execute(toolArgs) {
+        const res = await run(
+          args.agentBin,
+          ["mcp", "list-tools", toolArgs.serverName],
+          {
+            cwd: args.cwd,
+            timeoutMs: toolArgs.timeoutMs ?? 60_000,
+          },
+        );
+        if (res.code !== 0) {
+          throw new Error(
+            `agent mcp list-tools failed (exit ${res.code}).\n${res.stderr.trim()}`,
+          );
+        }
+        return res.stdout.trim();
       },
     }),
   };


### PR DESCRIPTION
## Summary

- **stream-json parser**: New NDJSON parser for Cursor CLI's `--output-format stream-json`, which surfaces tool calls (file reads, edits, shell commands) and assistant messages in structured summaries instead of discarding them
- **cursor_cli_run stream-json support**: Users can now pass `outputFormat: "stream-json"` to see exactly what Cursor CLI did (tool calls, intermediate steps, final response)
- **cursor_cli_patch uses stream-json**: Replaces raw `<cursor_stdout>` with structured `<cursor_activity>` showing Cursor's tool call activity alongside the patch
- **Bridge uses stream-json**: Switches from `--output-format text` to `stream-json`, extracting only assistant text for clean OpenAI responses (no tool call noise)
- **Bridge startup warning**: Logs a note about the agent-wrapping-agent limitation when the bridge starts
- **MCP tools**: New `cursor_cli_mcp_list` and `cursor_cli_mcp_tools` to expose Cursor CLI's MCP server management
- **Documentation**: New "Known limitations" section in README covering the nested agent loop problem and the missing OpenCode provider plugin API. New "Upstream dependencies" section in PLAN.md.
- **Version bump**: All packages bumped to 0.2.0